### PR TITLE
feat: Launching the provider in debug mode to enable debugger-based debugging

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,8 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 )
 
+const ProviderAddr = "registry.terraform.io/Snowflake-Labs/snowflake"
+
 func main() {
 	version := flag.Bool("version", false, "spit out version for resources here")
+	debug := flag.Bool("debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
 
 	if *version {
@@ -24,6 +27,8 @@ func main() {
 	}
 
 	plugin.Serve(&plugin.ServeOpts{
+		Debug:        *debug,
+		ProviderAddr: ProviderAddr,
 		ProviderFunc: provider.Provider,
 	})
 }


### PR DESCRIPTION
Adding the -debug flag to enable starting the provider in debug mode according to https://www.terraform.io/plugin/debugging#debugger-based-debugging

Specifying the `ProviderAddr` was required to let the provider print the proper command to set the `TF_REATTACH_PROVIDERS` environment variable once theprovider is started in debug mode. If not specified, the output will default to `provider` which will print a wrong command to the user. With this wrong command the debug session will not be established between the provider and the Terraform applicaiton. 

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] unit tests
* [ ] acceptance tests
<!-- add more below if you think they are relevant -->
* [x] manual testing with the following steps on Windows with VS Code
1. Launch the Snowflake Provider in VS Code debugger with the `-debug` argument. The process prints the following 
    ```
    Provider started. To attach Terraform CLI, set the TF_REATTACH_PROVIDERS environment variable with the following:

	Command Prompt:	set "TF_REATTACH_PROVIDERS={"registry.terraform.io/Snowflake-Labs/snowflake":{"Protocol":"grpc","ProtocolVersion":5,"Pid":35140,"Test":true,"Addr":{"Network":"tcp","String":"127.0.0.1:54706"}}}"
	PowerShell:	$env:TF_REATTACH_PROVIDERS='{"registry.terraform.io/Snowflake-Labs/snowflake":{"Protocol":"grpc","ProtocolVersion":5,"Pid":35140,"Test":true,"Addr":{"Network":"tcp","String":"127.0.0.1:54706"}}}'
   ```
2. In another command line window, execute the SET command printed in the previous step.
3. Execute any Terraform template exercising the Snowflake Terraform provider.
4. Verify that Terraform connects to the debug session by checking the outputted messages in the Debug Console in VS Code.
5. Place breakpoints in the code and check if the execution stops when execution reaches the breakpoint.

## References
<!-- issues documentation links, etc  -->

* 